### PR TITLE
scale max steer delta up to match torque

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -11,8 +11,8 @@
 const int GM_MAX_STEER = 300;
 const int GM_MAX_RT_DELTA = 128;          // max delta torque allowed for real time checks
 const int32_t GM_RT_INTERVAL = 250000;    // 250ms between real time checks
-const int GM_MAX_RATE_UP = 7;
-const int GM_MAX_RATE_DOWN = 17;
+const int GM_MAX_RATE_UP = 8;
+const int GM_MAX_RATE_DOWN = 20;
 const int GM_DRIVER_TORQUE_ALLOWANCE = 50;
 const int GM_DRIVER_TORQUE_FACTOR = 4;
 const int GM_MAX_GAS = 3072;


### PR DESCRIPTION
if were keeping with a time to peak torque of 0.75 sec and peak torque to zero 0.3 sec we need to being up the delta now that max torque was changed to 300
300 / 50 / 0.75

the deltas are still set for a max torque of 250 instead of 300

this actually makes a noticeable difference